### PR TITLE
Add CORS headers for preflight

### DIFF
--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -58,6 +58,12 @@ class AuthController extends Controller
         if ($action->id === 'index') {
             $this->enableCsrfValidation = \jasonmccallister\hasura\Hasura::$plugin->getSettings()->requireCsrfToken;
         }
+        
+        if (Craft::$app->getRequest()->isOptions) {
+            Craft::$app->getResponse()->getHeaders()->set('Access-Control-Allow-Origin', '*');
+            Craft::$app->getResponse()->getHeaders()->add('Access-Control-Allow-Headers', "X-Requested-With, Authorization, Content-Type, Request-Method");
+            Craft::$app->end();
+        }
 
         return parent::beforeAction($action);
     }

--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -61,7 +61,7 @@ class AuthController extends Controller
         
         if (Craft::$app->getRequest()->isOptions) {
             Craft::$app->getResponse()->getHeaders()->set('Access-Control-Allow-Origin', '*');
-            Craft::$app->getResponse()->getHeaders()->add('Access-Control-Allow-Headers', "X-Requested-With, Authorization, Content-Type, Request-Method");
+            Craft::$app->getResponse()->getHeaders()->set('Access-Control-Allow-Headers', "X-Requested-With, Authorization, Content-Type, Request-Method");
             Craft::$app->end();
         }
 


### PR DESCRIPTION
I came across the same issue again in another project and figured out a way to get around the preflight issue within the plugin itself.

Tested with Nitro 1.0.1 and fresh CraftCMS (example.test) installation + Hasura Auth Plugin. Call was made with `HttpClientModule` within Angular 10 (localhost:4200):
`this.http.post<TokenResponse>(http://example.test/hasura/auth, { loginName, password })`

related to #5