### PR TITLE
Fix error if no user for given loginName

### DIFF
--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -76,7 +76,7 @@ class AuthController extends Controller
         $password = Craft::$app->getRequest()->getRequiredBodyParam('password');
         $user = Craft::$app->getUsers()->getUserByUsernameOrEmail($loginName);
 
-        if (!$user->authenticate($password)) {
+        if (!$user || !$user->authenticate($password)) {
             return $this->asErrorJson('Unable to authenticate the user');
         }
 


### PR DESCRIPTION
otherwise the backend fails with `Call to a member function authenticate() on null`