### PR TITLE
Feature/set default role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.0.0 - 2019-03-15
+## 1.2.0 - 2020-09-24
+
 ### Added
+
+- Add ability to write custom claims via twig
+
+## 1.1.0 - 2019-05-24
+
+### Added
+
+- Add docs for webhook
+
+## 1.0.0 - 2019-03-15
+
+### Added
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -97,3 +97,39 @@ The event contains the following:
 - payload: The payload of the event, which is [contains the new and old data](https://docs.hasura.io/1.0/graphql/manual/event-triggers/payload.html#json-payload) (based on the trigger type)
 
 Brought to you by [Jason McCallister](https://mccallister.io)
+
+## Add Custom Claims via Twig field in Plugin Settings
+
+You can add custom claims (for example the users name or a custom field) to the JWT token via the new Custom Claims field in the Plugin settings.
+You can add any additional information as well as user specific details as he field accepts the `user` variable. In Hasura you are then able to write rules based on the `x-hasura-custom-claim` object.
+
+### Example twig query
+
+```twig
+{% set customCategory = user.customCategory.one() %}
+{% if customCategory %}
+  {% set jsonObject = { "uid": customCategory, "title": customCategory, "slug": customCategory } %}
+  {{ jsonObject |json_encode() }}
+{% endif %}
+```
+
+### Example JWT
+
+```json
+{
+  "sub": "04fc4392-02ce-4718-bd93-788c1b5e55f4",
+  "admin": true,
+  "iat": 1553079269,
+  "exp": 1553082869,
+  "https://hasura.io/jwt/claims": {
+    "x-hasura-allowed-roles": ["user", "admin"],
+    "x-hasura-default-role": "admin",
+    "x-hasura-user-id": "04fc4392-02ce-4718-bd93-788c1b5e55f4",
+    "x-hasura-custom-claim": {
+      "uid": "071cd618-e675-4bcc-b362-0311b43333c9",
+      "title": "Category Name",
+      "slug": "category-name"
+    }
+  }
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -1,39 +1,45 @@
 {
-    "name": "jasonmccallister/hasura",
-    "description": "Use your Craft CMS credentials to authenticate with a GraphQL API powered by Hasura.io",
-    "type": "craft-plugin",
-    "version": "1.1.0",
-    "keywords": [
-        "craft",
-        "cms",
-        "craftcms",
-        "craft-plugin",
-        "hasura"
-    ],
-    "support": {
-        "docs": "https://github.com/jasonmccallister/craft-hasura/blob/master/README.md",
-        "issues": "https://github.com/jasonmccallister/craft-hasura/issues"
+  "name": "jasonmccallister/hasura",
+  "description": "Use your Craft CMS credentials to authenticate with a GraphQL API powered by Hasura.io",
+  "type": "craft-plugin",
+  "version": "1.1.0",
+  "keywords": [
+    "craft",
+    "cms",
+    "craftcms",
+    "craft-plugin",
+    "hasura"
+  ],
+  "support": {
+    "docs": "https://github.com/jasonmccallister/craft-hasura/blob/master/README.md",
+    "issues": "https://github.com/jasonmccallister/craft-hasura/issues"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Jason McCallister",
+      "homepage": "https://mccallister.io"
     },
-    "license": "MIT",
-    "authors": [{
-        "name": "Jason McCallister",
-        "homepage": "https://mccallister.io"
-    }],
-    "require": {
-        "craftcms/cms": "^3.0.0-RC1",
-        "firebase/php-jwt": "^5.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "jasonmccallister\\hasura\\": "src/"
-        }
-    },
-    "extra": {
-        "name": "Hasura",
-        "handle": "hasura",
-        "hasCpSettings": true,
-        "hasCpSection": false,
-        "changelogUrl": "https://raw.githubusercontent.com/jasonmccallister/hasura/master/CHANGELOG.md",
-        "class": "jasonmccallister\\hasura\\Hasura"
+    {
+      "name": "Denis Yilmaz",
+      "homepage": "https://ynm.studio"
     }
+  ],
+  "require": {
+    "craftcms/cms": "^3.0.0-RC1",
+    "firebase/php-jwt": "^5.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "jasonmccallister\\hasura\\": "src/"
+    }
+  },
+  "extra": {
+    "name": "Hasura",
+    "handle": "hasura",
+    "hasCpSettings": true,
+    "hasCpSection": false,
+    "changelogUrl": "https://raw.githubusercontent.com/jasonmccallister/hasura/master/CHANGELOG.md",
+    "class": "jasonmccallister\\hasura\\Hasura"
+  }
 }

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Hasura plugin for Craft CMS 3.x
  *
@@ -35,6 +36,15 @@ class Encoder
         $iat = time();
         $exp = $iat + $duration;
 
+        $customClaim = [];
+        try {
+            $userElement = Craft::$app->getUsers()->getUserByUid($user->uid);
+            $customClaim = Json::decodeIfJson(Craft::$app->view->renderString($settings->fieldTwig, ['user' => $userElement]));
+        } catch (\Exception $e) {
+            Craft::error('Couldn’t render custom claim for user with id “' . $user->id . ' (' . $e->getMessage() . ').', __METHOD__);
+        }
+
+
         $token = [
             'sub' => $user->uid,
             'admin' => $user->admin ?? false,
@@ -44,6 +54,7 @@ class Encoder
                 'x-hasura-allowed-roles' => $roles,
                 'x-hasura-default-role' => $default,
                 'x-hasura-user-id' => $user->uid,
+                'x-hasura-custom-claim' => $customClaim,
             ]
         ];
 

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -31,7 +31,7 @@ class Encoder
         $defaultRole = $settings->defaultRole;
         $namespace = $settings->claimsNamespace;
 
-        $default = $user->admin ? 'admin' : $defaultRole;
+        $default = $user->admin ? 'admin' : (!empty($roles) ? end($roles) : $defaultRole);
 
         $iat = time();
         $exp = $iat + $duration;

--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -58,6 +58,12 @@ class AuthController extends Controller
         if ($action->id === 'index') {
             $this->enableCsrfValidation = \jasonmccallister\hasura\Hasura::$plugin->getSettings()->requireCsrfToken;
         }
+        
+        if (Craft::$app->getRequest()->isOptions) {
+            Craft::$app->getResponse()->getHeaders()->set('Access-Control-Allow-Origin', '*');
+            Craft::$app->getResponse()->getHeaders()->set('Access-Control-Allow-Headers', "X-Requested-With, Authorization, Content-Type, Request-Method");
+            Craft::$app->end();
+        }
 
         return parent::beforeAction($action);
     }

--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -82,7 +82,7 @@ class AuthController extends Controller
         $password = Craft::$app->getRequest()->getRequiredBodyParam('password');
         $user = Craft::$app->getUsers()->getUserByUsernameOrEmail($loginName);
 
-        if (!$user->authenticate($password)) {
+        if (!$user || !$user->authenticate($password)) {
             return $this->asErrorJson('Unable to authenticate the user');
         }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Hasura plugin for Craft CMS 3.x
  *
@@ -38,6 +39,13 @@ class Settings extends Model
      * @var string
      */
     public $claimsNamespace = 'https://hasura.io/jwt/claims';
+
+    /**
+     * Twig string to be parsed on include
+     *
+     * @var string
+     */
+    public $fieldTwig = '';
 
     /**
      * require CSRF token model attribute

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -105,3 +105,13 @@ General Settings
     name: 'claimsNamespace',
     value: settings['claimsNamespace']})
 }}
+
+{{ forms.textareaField( {
+    label: "Custom Claims"|t,
+    instructions: "Enter the twig code that you want to parse when token is generated."|t,
+    id: 'fieldTwig',
+    name: 'fieldTwig',
+    value: settings['fieldTwig'],
+    class: 'code',
+    rows: 10
+}) }}


### PR DESCRIPTION
Currently, if the user is not an admin, only the default role from the settings page is returned in the JWT.
This update takes the last role from the roles array and sets it as the default. This way GraphQL queries can be made only with the Bearer Token as Hasura checks the `x-hasura-default-role` for permissions if no `x-hasura-role` header is send.