### PR TITLE
Feature/set default role

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -30,7 +30,7 @@ class Encoder
         $defaultRole = $settings->defaultRole;
         $namespace = $settings->claimsNamespace;
 
-        $default = $user->admin ? 'admin' : $defaultRole;
+        $default = $user->admin ? 'admin' : (!empty($roles) ? end($roles) : $defaultRole);
 
         $iat = time();
         $exp = $iat + $duration;


### PR DESCRIPTION
Currently, if the user is not an admin, only the default role from the settings page is returned in the JWT.
This update takes the last `userRole` from the `userRoles` array and sets it as the `x-hasura-default-role`. This way GraphQL queries can be made only with the Bearer Token as Hasura checks the `x-hasura-default-role` for permissions if no `x-hasura-role` header is send.