### PR TITLE
Add missing class import

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -2,6 +2,7 @@
 
 namespace jasonmccallister\hasura;
 
+use Craft;
 use Firebase\JWT\JWT;
 use craft\elements\User;
 


### PR DESCRIPTION
Currently calling the `/hasura/auth` action results in an server error:

```bash
Class 'jasonmccallister\hasura\Craft' not found in /var/www/html/vendor/jasonmccallister/hasura/src/Encoder.php at line 44
```